### PR TITLE
Sort features only once per split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "permutation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +224,7 @@ dependencies = [
 name = "rustrees"
 version = "0.1.0"
 dependencies = [
+ "permutation",
  "pyo3",
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ crate-type = ["cdylib"]
 [dependencies]
 rand = "0.8.5"
 pyo3 = { version = "0.18.1", features = ["extension-module"] }
+permutation = "0.4.1"

--- a/src/tree_node.rs
+++ b/src/tree_node.rs
@@ -10,6 +10,7 @@ use rand::SeedableRng;
 use std::cmp::Ordering::Equal;
 use std::collections::HashMap;
 
+use permutation;
 use pyo3::prelude::*;
 
 #[pyclass]
@@ -129,11 +130,13 @@ impl TreeNode {
         let mut left_dataset = train.clone_without_data();
         let mut right_dataset = train.clone_without_data();
 
+        let best_feature_sorter =
+            permutation::sort_by(&train.feature_matrix[best_feature.col_index], |a, b| {
+                a.partial_cmp(b).unwrap_or(Equal)
+            });
+
         for i in 0..train.feature_names.len() {
-            let (_, sorted_feature) = utils::sort_two_vectors(
-                &train.feature_matrix[best_feature.col_index],
-                &train.feature_matrix[i],
-            );
+            let sorted_feature = best_feature_sorter.apply_slice(&train.feature_matrix[i]);
 
             let mut first_half = sorted_feature.clone();
             let second_half = first_half.split_off(best_feature.row_index);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,12 @@
 use std::cmp::Ordering::Equal;
+use permutation;
 
 pub fn sort_two_vectors(a: &[f32], b: &[f32]) -> (Vec<f32>, Vec<f32>) {
-    let mut pairs: Vec<(&f32, &f32)> = a.iter().zip(b).collect();
-    pairs.sort_by(|&a, &b| a.0.partial_cmp(b.0).unwrap_or(Equal));
+    let a_sorter = permutation::sort_by(a, |a, b| a.partial_cmp(b).unwrap_or(Equal));
 
-    pairs.into_iter().map(|(x, y)| (*x, *y)).unzip()
+    let a = a_sorter.apply_slice(a);
+    let b = a_sorter.apply_slice(b);
+    (a, b)
 }
 
 pub fn float_avg(x: &[f32]) -> f32 {


### PR DESCRIPTION
I ran the flamegraph profiler and the `sort_two_vectors` was showing up as one of the functions that was taking a lot of time.

![image](https://user-images.githubusercontent.com/19623477/227054879-2028867a-e63b-4be6-a864-b1f78c9c4c90.png)


Under inspection we were sorting every feature with the criteria of the best feature. But the permutation is always the same no need to redecide the permutation.

Luckly there is a crate `permutation` that does exactly this. So I used it and saw a 30% improvement in training time.

![image](https://user-images.githubusercontent.com/19623477/227054737-ded02e90-4df3-494f-aed3-4d9ca8a01010.png)
