### PR TITLE
Add doc comments to rust code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,13 @@
 //! ```rust
 //! use rustrees::{DecisionTree, Dataset, r2};
 //! 
-//! let dataset = Dataset::read_csv("iris.csv", ",");
+//! let dataset = Dataset::read_csv("datasets/titanic_train.csv", ",");
 //! 
 //! let dt = DecisionTree::train_reg(
 //!    &dataset, 
-//!    5,        // max_depth
+//!    Some(5),        // max_depth
 //!    Some(1),  // min_samples_leaf        
+//!    None,     // max_features (None = all features)
 //!    Some(42), // random_state
 //! );
 //! 
@@ -35,6 +36,7 @@ pub use trees::DecisionTree;
 pub use trees::RandomForest;
 pub use trees::TrainOptions;
 pub use trees::Tree;
+pub use utils::{accuracy, r2};
 
 use pyo3::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,29 @@
+//! Rustrees is a library for building decision trees and random forests.
+//!
+//! The goal is to provide a fast implementation of decision trees in rust, with a python API.
+//!
+//! Example usage:
+//!
+//! ```rust
+//! use rustrees::{DecisionTree, Dataset, r2};
+//! 
+//! let dataset = Dataset::read_csv("iris.csv", ",");
+//! 
+//! let dt = DecisionTree::train_reg(
+//!    &dataset, 
+//!    5,        // max_depth
+//!    Some(1),  // min_samples_leaf        
+//!    Some(42), // random_state
+//! );
+//! 
+//! let pred = dt.predict(&dataset);
+//! 
+//! println!("r2 score: {}", r2(&dataset.target_vector, &pred));
+//!
+//! ```
+//!
+
+
 mod dataset;
 mod split_criteria;
 mod tests;
@@ -9,7 +35,6 @@ pub use trees::DecisionTree;
 pub use trees::RandomForest;
 pub use trees::TrainOptions;
 pub use trees::Tree;
-pub use utils::*;
 
 use pyo3::prelude::*;
 

--- a/src/split_criteria.rs
+++ b/src/split_criteria.rs
@@ -1,5 +1,6 @@
 use crate::utils;
 
+/// A common interface for different split criteria.
 pub(crate) type SplitFunction = fn(
     col_index: usize,
     feature_name: &str,
@@ -7,10 +8,6 @@ pub(crate) type SplitFunction = fn(
     feature: &[f32],
     target: &[f32],
 ) -> SplitResult;
-
-//pub(crate) trait SplitCriteria {
-//    fn split_feature(col_index: usize, feature: &[f32], target: &[f32]) -> SplitResult;
-//}
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct SplitResult {
@@ -35,9 +32,9 @@ impl SplitResult {
     }
 }
 
-//pub(crate) struct MeanSquaredError;
 
-//impl SplitCriteria for MeanSquaredError {
+/// The split criteria used for regression problems. The mean squared error has a special form
+/// that allows to compute the loss of all splits reusing most of the computation across splits.
 pub(crate) fn mean_squared_error_split_feature(
     col_index: usize,
     feature_name: &str,
@@ -100,11 +97,9 @@ pub(crate) fn mean_squared_error_split_feature(
         loss: min_mse,
     }
 }
-//}
 
-//pub(crate) struct GiniCoefficient;
 
-//impl SplitCriteria for GiniCoefficient {
+/// The split criteria used for classification problems.
 pub(crate) fn gini_coefficient_split_feature(
     col_index: usize,
     feature_name: &str,
@@ -160,7 +155,6 @@ pub(crate) fn gini_coefficient_split_feature(
         loss: min_gini,
     }
 }
-//}
 
 #[cfg(test)]
 mod test {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{trees::RandomForest, *};
+    use crate::{utils::classification_threshold, utils::r2, utils::accuracy};
 
     fn assert_greater_than(a: f32, b: f32) {
         if a <= b {
@@ -10,7 +11,6 @@ mod tests {
 
     #[test]
     fn test_integration() {
-        let a = Box::new(5);
         let train = Dataset::read_csv("datasets/diabetes_train.csv", ",");
         let test = Dataset::read_csv("datasets/diabetes_test.csv", ",");
         let dt = DecisionTree::train_reg(&train, Some(5), Some(1), None, Some(42));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,6 +10,7 @@ mod tests {
 
     #[test]
     fn test_integration() {
+        let a = Box::new(5);
         let train = Dataset::read_csv("datasets/diabetes_train.csv", ",");
         let test = Dataset::read_csv("datasets/diabetes_test.csv", ",");
         let dt = DecisionTree::train_reg(&train, Some(5), Some(1), None, Some(42));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,8 @@
 use std::cmp::Ordering::Equal;
 
-pub fn sort_two_vectors(a: &[f32], b: &[f32]) -> (Vec<f32>, Vec<f32>) {
+/// Sorts two vectors by the first one. This is used to sort target by feature and it is at the
+/// core of the decision tree algorithm. 
+pub(crate) fn sort_two_vectors(a: &[f32], b: &[f32]) -> (Vec<f32>, Vec<f32>) {
     let a_sorter = permutation::sort_by(a, |a, b| a.partial_cmp(b).unwrap_or(Equal));
 
     let a = a_sorter.apply_slice(a);
@@ -8,17 +10,21 @@ pub fn sort_two_vectors(a: &[f32], b: &[f32]) -> (Vec<f32>, Vec<f32>) {
     (a, b)
 }
 
-pub fn float_avg(x: &[f32]) -> f32 {
+pub(crate) fn float_avg(x: &[f32]) -> f32 {
     x.iter().sum::<f32>() / x.len() as f32
 }
 
-pub fn classification_threshold(x: &[f32], clf_threshold: f32) -> Vec<f32> {
+/// computes the classification threshold for a given vector. This is used for testing the
+#[cfg(test)]
+pub(crate) fn classification_threshold(x: &[f32], clf_threshold: f32) -> Vec<f32> {
     x.iter()
         .map(|&x| if x >= clf_threshold { 1.0 } else { 0.0 })
         .collect()
 }
 
-pub fn r2(x_true: &[f32], x_pred: &[f32]) -> f32 {
+/// computes the mean squared error between two vectors used for testing regression case.
+#[cfg(test)]
+pub(crate) fn r2(x_true: &[f32], x_pred: &[f32]) -> f32 {
     let mse: f32 = x_true
         .iter()
         .zip(x_pred)
@@ -31,7 +37,9 @@ pub fn r2(x_true: &[f32], x_pred: &[f32]) -> f32 {
     1.0 - mse / var
 }
 
-pub fn accuracy(x_true: &[f32], x_pred: &[f32]) -> f32 {
+/// computes the accuracy of a binary classification. Used for testing.
+#[cfg(test)]
+pub(crate) fn accuracy(x_true: &[f32], x_pred: &[f32]) -> f32 {
     x_true
         .iter()
         .zip(x_pred)
@@ -40,7 +48,7 @@ pub fn accuracy(x_true: &[f32], x_pred: &[f32]) -> f32 {
         / x_true.len() as f32
 }
 
-pub fn get_rng(maybe_seed: Option<u64>, offset: u64) -> rand::rngs::StdRng {
+pub(crate) fn get_rng(maybe_seed: Option<u64>, offset: u64) -> rand::rngs::StdRng {
     match maybe_seed {
         Some(seed) => rand::SeedableRng::seed_from_u64(seed + offset),
         None => rand::SeedableRng::from_entropy(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,8 +23,7 @@ pub(crate) fn classification_threshold(x: &[f32], clf_threshold: f32) -> Vec<f32
 }
 
 /// computes the mean squared error between two vectors used for testing regression case.
-#[cfg(test)]
-pub(crate) fn r2(x_true: &[f32], x_pred: &[f32]) -> f32 {
+pub fn r2(x_true: &[f32], x_pred: &[f32]) -> f32 {
     let mse: f32 = x_true
         .iter()
         .zip(x_pred)
@@ -38,8 +37,7 @@ pub(crate) fn r2(x_true: &[f32], x_pred: &[f32]) -> f32 {
 }
 
 /// computes the accuracy of a binary classification. Used for testing.
-#[cfg(test)]
-pub(crate) fn accuracy(x_true: &[f32], x_pred: &[f32]) -> f32 {
+pub fn accuracy(x_true: &[f32], x_pred: &[f32]) -> f32 {
     x_true
         .iter()
         .zip(x_pred)


### PR DESCRIPTION
We can generate docs from these comments using

```bash
cargo doc --open
```

I also believe that cargo.io generates these docs for crates stored there.

![image](https://github.com/tabacof/rust-trees/assets/19623477/440c9094-546f-42f6-bf42-561827e31b73)
